### PR TITLE
refactor(cloudfront-config): use ACMCertificateArn property to identify certs

### DIFF
--- a/cloudfront-config.js
+++ b/cloudfront-config.js
@@ -58,7 +58,7 @@ module.exports = function (config) {
       PriceClass: 'PriceClass_100',
       ViewerCertificate: {
         CloudFrontDefaultCertificate: !config.certId,
-        IAMCertificateId: config.certId,
+        ACMCertificateArn: config.certId,
         MinimumProtocolVersion: 'TLSv1',
         SSLSupportMethod: 'sni-only'
       }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function respond (done) {
     if (err) return done(err)
     var result = {
       url: data.DomainName,
-      certId: data.DistributionConfig.ViewerCertificate.IAMCertificateId,
+      certId: data.DistributionConfig.ViewerCertificate.AWSCertificateArn,
       distribution: data
     }
     done(null, result)


### PR DESCRIPTION
Fixes an issue with CloudFront's new requirements to identify an SSL certificate when changing the allowed CNAMEs of a distribution.

Because all of our SSL certs are managed by ACM, we want to supply the `ACMCertificateArn` property instead of the `IAMCertificateId` property, which was previously hard-coded.

A better implementation might allow configuring which property needs to be set, but since all our SSL certs are managed by ACM I think this is fine for now.